### PR TITLE
Add command line arguments for login server port parameters

### DIFF
--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -364,7 +364,6 @@ int __cdecl main(int argc, char* argv[])
                 std::string polcorecmd = " /game eAZcFcB -net 3 -port " + g_LoginViewPort;
                 //Cast to an LPSTR
                 LPSTR cmd = const_cast<char*>(polcorecmd.c_str());
-                xiloader::console::output(xiloader::color::warning, "Cmd: %s", cmd);
                 polcore->SetAreaCode(g_Language);
                 polcore->SetParamInit(GetModuleHandle(NULL), cmd);
 

--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -33,6 +33,9 @@ This file is part of DarkStar-server source code.
 xiloader::Language g_Language = xiloader::Language::English; // The language of the loader to be used for polcore.
 std::string g_ServerAddress = "127.0.0.1"; // The server address to connect to.
 std::string g_ServerPort = "51220"; // The server lobby server port to connect to.
+std::string g_LoginDataPort = "54230"; // Login server data port to connect to
+std::string g_LoginViewPort = "54001"; // Login view port to connect to
+std::string g_LoginAuthPort = "54231"; // Login auth port to connect to
 std::string g_Username = ""; // The username being logged in with.
 std::string g_Password = ""; // The password being logged in with.
 char* g_CharacterList = NULL; // Pointer to the character list data being sent from the server.
@@ -250,9 +253,30 @@ int __cdecl main(int argc, char* argv[])
         }
 
         /* Server Port Argument */
-        if (!_strnicmp(argv[x], "--port", 6))
+        if (!_strnicmp(argv[x], "--serverport", 6))
         {
             g_ServerPort = argv[++x];
+            continue;
+        }
+
+        /* Login Data Port Argument */
+        if (!_strnicmp(argv[x], "--dataport", 6))
+        {
+            g_LoginDataPort = argv[++x];
+            continue;
+        }
+
+        /* Login View Port Argument */
+        if (!_strnicmp(argv[x], "--viewport", 6))
+        {
+            g_LoginViewPort = argv[++x];
+            continue;
+        }
+
+        /* Login Auth Port Argument */
+        if (!_strnicmp(argv[x], "--authport", 6))
+        {
+            g_LoginAuthPort = argv[++x];
             continue;
         }
 
@@ -310,7 +334,7 @@ int __cdecl main(int argc, char* argv[])
 
         /* Attempt to create socket to server..*/
         xiloader::datasocket sock;
-        if (xiloader::network::CreateConnection(&sock, "54231"))
+        if (xiloader::network::CreateConnection(&sock, g_LoginAuthPort.c_str()))
         {
             /* Attempt to verify the users account info.. */
             while (!xiloader::network::VerifyAccount(&sock))
@@ -336,8 +360,12 @@ int __cdecl main(int argc, char* argv[])
             else
             {
                 /* Invoke the setup functions for polcore.. */
+                //Create string for the login view port
+                std::string polcorecmd = " /game eAZcFcB -net 3 " + g_LoginViewPort;
+                //Cast to an LPSTR
+                LPSTR cmd = const_cast<char*>(polcorecmd.c_str());
                 polcore->SetAreaCode(g_Language);
-                polcore->SetParamInit(GetModuleHandle(NULL), " /game eAZcFcB -net 3");
+                polcore->SetParamInit(GetModuleHandle(NULL), cmd);
 
                 /* Obtain the common function table.. */
                 void * (**lpCommandTable)(...);

--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -361,9 +361,10 @@ int __cdecl main(int argc, char* argv[])
             {
                 /* Invoke the setup functions for polcore.. */
                 //Create string for the login view port
-                std::string polcorecmd = " /game eAZcFcB -net 3 " + g_LoginViewPort;
+                std::string polcorecmd = " /game eAZcFcB -net 3 -port " + g_LoginViewPort;
                 //Cast to an LPSTR
                 LPSTR cmd = const_cast<char*>(polcorecmd.c_str());
+                xiloader::console::output(xiloader::color::warning, "Cmd: %s", cmd);
                 polcore->SetAreaCode(g_Language);
                 polcore->SetParamInit(GetModuleHandle(NULL), cmd);
 

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -28,6 +28,9 @@ extern std::string g_ServerAddress;
 extern std::string g_Username;
 extern std::string g_Password;
 extern std::string g_ServerPort;
+extern std::string g_LoginDataPort;
+extern std::string g_LoginViewPort;
+extern std::string g_LoginAuthPort;
 extern char* g_CharacterList;
 extern bool g_IsRunning;
 
@@ -221,7 +224,7 @@ namespace xiloader
         /* Create connection if required.. */
         if (sock->s == NULL || sock->s == INVALID_SOCKET)
         {
-            if (!xiloader::network::CreateConnection(sock, "54231"))
+            if (!xiloader::network::CreateConnection(sock, g_LoginAuthPort.c_str()))
                 return false;
         }
 
@@ -567,7 +570,7 @@ namespace xiloader
     DWORD __stdcall network::FFXiServer(LPVOID lpParam)
     {
         /* Attempt to create connection to the server.. */
-        if (!xiloader::network::CreateConnection((xiloader::datasocket*)lpParam, "54230"))
+        if (!xiloader::network::CreateConnection((xiloader::datasocket*)lpParam, g_LoginDataPort.c_str()))
             return 1;
 
         /* Attempt to start data communication with the server.. */

--- a/xiloader/xiloader.vcxproj
+++ b/xiloader/xiloader.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{1F160572-CDDD-4485-BBE4-AE854E36A2E6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xiloader</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/xiloader/xiloader.vcxproj
+++ b/xiloader/xiloader.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{1F160572-CDDD-4485-BBE4-AE854E36A2E6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xiloader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
The LSB login.conf gives options to change 3 ports for the login server:

```
login_data_ip: 0.0.0.0
login_data_port: 54230
login_view_ip: 0.0.0.0
login_view_port: 54001
login_auth_ip: 0.0.0.0
login_auth_port: 54231
```

These ports were hardcoded into the loader.  I added three command line arguments to change the ports the loader connects to via command line arguments instead

--dataport
--viewport
--authport