### PR TITLE
Load ids from same spot

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -460,7 +460,7 @@ namespace xiloader
                     g_CharacterList[0x18 + (x * 0x68)] = 0x20;
                     g_CharacterList[0x28 + (x * 0x68)] = 0x20;
 
-                    memcpy(g_CharacterList + 0x04 + (x * 0x68), recvBuffer + 0x14 * (x + 1), 4); // Character Id
+                    memcpy(g_CharacterList + 0x04 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4); // Character Id
                     memcpy(g_CharacterList + 0x08 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4); // Content Id
                 }
                 sendSize = 0;


### PR DESCRIPTION
Currently the lobby server sends a packet that sets Content Id and Character Id in two spots that over lap when the certain slots are both filled with charaterdata those slots are slot 4 and 5 ,slot 8 and 10,and slot 12 and 15. This change ignores looking in two spots for Character Id and Content Id as they are both set to Character Id by the lobby server.  This changes no current functionality, while also being backwards compatible with older boot loaders.