### PR TITLE
[build] Ensure release config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
         shell: cmd
         run: |
           mkdir build
-          cmake -S . -B build -A Win32
+          cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -A Win32
       - name: Build
         shell: cmd
         run: |
-          cmake --build build
+          # https://stackoverflow.com/a/19026241
+          cmake --build build --config Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cmake --build build
+          # https://stackoverflow.com/a/19026241
+          cmake --build build --config Release
       - name: Get Exe Hash
         id: hashes
         shell: pwsh


### PR DESCRIPTION
Had a report that the produced and released binary was Debug, so after a little googling, it turns out that defining the build type at configuration time isn't enough, it has to also be at build time