### PR TITLE
Add correct offset to handle character ID vs content ID.

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -460,8 +460,8 @@ namespace xiloader
                     g_CharacterList[0x18 + (x * 0x68)] = 0x20;
                     g_CharacterList[0x28 + (x * 0x68)] = 0x20;
 
-                    memcpy(g_CharacterList + 0x04 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4); // Character Id
-                    memcpy(g_CharacterList + 0x08 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4); // Content Id
+                    memcpy(g_CharacterList + 0x04 + (x * 0x68), recvBuffer + 0x10 * (x + 1) + 0x04, 4); // Character Id
+                    memcpy(g_CharacterList + 0x08 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4);        // Content Id
                 }
                 sendSize = 0;
                 break;


### PR DESCRIPTION
Does what it says on the tin. This is a companion PR to fix char IDs above 65535. See https://github.com/LandSandBoat/server/pull/3780

Test logic is to build this xiloader and connect to an existing server. This will not effect char IDs below 65536 in any way.