### PR TITLE
[cmake] Update argparse git tag in cmake

### DIFF
--- a/cmake/argparse.cmake
+++ b/cmake/argparse.cmake
@@ -1,5 +1,5 @@
 CPMAddPackage(
   NAME argparse
   GITHUB_REPOSITORY p-ranav/argparse
-  GIT_TAG 4cacdc4b30da8e9bdc8aefb6dea575b345da8b2b
+  GIT_TAG 557948f1236db9e27089959de837cc23de6c6bbd
 )


### PR DESCRIPTION
This may fix a bug with --hairpin, see #10 