### PR TITLE
[cmake] Set Large Address Aware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(xiloader
     src/network.h
     src/polcore.h)
 
+set_target_properties(xiloader PROPERTIES LINK_FLAGS "/LARGEADDRESSAWARE")
+
 target_include_directories(xiloader PUBLIC ${PROJECT_SOURCE_DIR}/xiloader)
 target_link_libraries(xiloader PUBLIC detours argparse psapi ws2_32)
 


### PR DESCRIPTION
This will make it so end users no longer require to set this flag when getting the executable. It is commonly set because of .DAT mods causing "black screens" where the zone does not load.