### PR TITLE
V1.1.2 update, upgrades mbedtls

### DIFF
--- a/cmake/mbedtls.cmake
+++ b/cmake/mbedtls.cmake
@@ -1,7 +1,7 @@
 CPMAddPackage(
   NAME mbedtls
   GITHUB_REPOSITORY Mbed-TLS/mbedtls
-  GIT_TAG 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+  GIT_TAG mbedtls-3.6.2
   OPTIONS
     "ENABLE_PROGRAMS OFF"
     "ENABLE_TESTING OFF"

--- a/src/console.h
+++ b/src/console.h
@@ -90,6 +90,8 @@ namespace xiloader
          */
         static void visible(bool visible);
 
+    public:
+
         /**
          * @brief Prints a text fragment with the specified color to the console.
          * 
@@ -97,8 +99,6 @@ namespace xiloader
          * @param message   The fragment to print.
          */
         static void print(xiloader::color c, std::string const& message);
-
-    public:
 
         /**
          * @brief Prints the given message to the console.
@@ -112,15 +112,7 @@ namespace xiloader
             output(xiloader::color::white, format, args...);
         }
 
-        /**
-         * @brief Prints the given message to the console with the specific color.
-         *
-         * @param c         The color to print the message with.
-         * @param format    The format of the message to print.
-         * @param args      The arguments to fill the format.
-         */
-        template<typename... Args>
-        static void output(xiloader::color c, char const* format, Args... args)
+        static std::string getTimestamp()
         {
             /* Get the current timestamp */
             ::__time32_t rawtime;
@@ -133,8 +125,22 @@ namespace xiloader
             char timestamp[256];
             ::strftime(timestamp, sizeof timestamp, "[%m/%d/%y %H:%M:%S] ", &timeinfo);
 
+            return timestamp;
+        }
+        /**
+         * @brief Prints the given message to the console with the specific color.
+         *
+         * @param c         The color to print the message with.
+         * @param format    The format of the message to print.
+         * @param args      The arguments to fill the format.
+         */
+        template<typename... Args>
+        static void output(xiloader::color c, char const* format, Args... args)
+        {
+            std::string timestamp = getTimestamp();
+
             /* Output the timestamp */
-            print(xiloader::color::lightyelllow, timestamp);
+            print(xiloader::color::lightyelllow, timestamp.c_str());
 
             /* Parse the incoming message */
             char buffer[1024];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ namespace globals
     std::string        g_Password        = "";                          // The password being logged in with.
     char               g_SessionHash[16] = {};                          // Session hash sent from auth
     std::string        g_Email           = "";                          // Email, currently unused
-    std::string        g_VersionNumber   = "1.1.1";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'. Remember to also change in xiloader.rc.in
+    std::string        g_VersionNumber   = "1.1.2";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'. Remember to also change in xiloader.rc.in
 
     char* g_CharacterList = NULL;  // Pointer to the character list data being sent from the server.
     bool  g_IsRunning     = false; // Flag to determine if the network threads should hault.
@@ -458,6 +458,7 @@ int __cdecl main(int argc, char* argv[])
     xiloader::console::output(xiloader::color::lightred, "==========================================================");
     xiloader::console::output(xiloader::color::lightgreen, "DarkStar Boot Loader (c) 2015 DarkStar Team");
     xiloader::console::output(xiloader::color::lightgreen, "LandSandBoat Boot Loader (c) 2021-%d LandSandBoat Team (v%s)", currentYear, globals::g_VersionNumber.c_str());
+    xiloader::console::output(xiloader::color::lightblue, "Using %s", MBEDTLS_VERSION_STRING_FULL); // this prints "Using Mbed TLS #.#.#"
     xiloader::console::output(xiloader::color::lightpurple, "Git Repo   : https://github.com/LandSandBoat/xiloader");
     xiloader::console::output(xiloader::color::lightpurple, "Bug Reports: https://github.com/LandSandBoat/xiloader/issues");
     xiloader::console::output(xiloader::color::lightred, "==========================================================");

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -196,14 +196,15 @@ namespace xiloader
             // If this is the only warning, just don't print it.
             if (flags != MBEDTLS_X509_BADCERT_NOT_TRUSTED)
             {
-                char vrfy_buf[512];
+                char        vrfy_buf[1024] = {};
+                std::string timestamp      = xiloader::console::getTimestamp();
 
                 flags &= ~MBEDTLS_X509_BADCERT_NOT_TRUSTED; // Don't report the cert isn't trusted -- we don't care.
 
-                mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
+                mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), timestamp.c_str(), flags);
 
                 xiloader::console::output(xiloader::color::warning, "Remote server certificate warnings:", vrfy_buf);
-                xiloader::console::output(xiloader::color::warning, "%s", vrfy_buf);
+                xiloader::console::print(xiloader::color::warning, vrfy_buf);
             }
         }
         else

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -192,12 +192,19 @@ namespace xiloader
 
         if ((flags = mbedtls_ssl_get_verify_result(&sslState::ssl)) != 0)
         {
-            char vrfy_buf[512];
+            // We genuinely don't care if the error flags is ONLY that the cert isn't trusted,
+            // If this is the only warning, just don't print it.
+            if (flags != MBEDTLS_X509_BADCERT_NOT_TRUSTED)
+            {
+                char vrfy_buf[512];
 
-            mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
+                flags &= ~MBEDTLS_X509_BADCERT_NOT_TRUSTED; // Don't report the cert isn't trusted -- we don't care.
 
-            xiloader::console::output(xiloader::color::warning, "Remote server certificate warnings:", vrfy_buf);
-            xiloader::console::output(xiloader::color::warning, "%s", vrfy_buf);
+                mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
+
+                xiloader::console::output(xiloader::color::warning, "Remote server certificate warnings:", vrfy_buf);
+                xiloader::console::output(xiloader::color::warning, "%s", vrfy_buf);
+            }
         }
         else
         {

--- a/src/xiloader.rc.in
+++ b/src/xiloader.rc.in
@@ -5,7 +5,7 @@ BEGIN
     BEGIN
         BLOCK "081604b0"
         BEGIN
-            VALUE "FileVersion", "1.1.1"
+            VALUE "FileVersion", "1.1.2"
         END
     END
 END


### PR DESCRIPTION
Small update here

- upgrades mbedtls (some security fixes were implemented)
- Ignores an annoying warning we don't care about
- now prints the version of mbedtls we are using
- better warning printing (no extra newlines)
- Version bump to 1.1.2
- supercedes #25 