### PR TITLE
V1.1.3, hint  to windows are are DPI aware, better logging, better detect when to use autologin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(xiloader
     src/network.h
     src/polcore.h
     ${CMAKE_CURRENT_BINARY_DIR}/src/xiloader.rc
+    xiloader.manifest
 )
 
 set_target_properties(xiloader PROPERTIES LINK_FLAGS "/LARGEADDRESSAWARE")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,9 +522,14 @@ int __cdecl main(int argc, char* argv[])
 
     /* Attempt to resolve the server address.. */
     ULONG ulAddress = 0;
+
+    xiloader::console::output(xiloader::color::info, "Resolving '%s' ...", globals::g_ServerAddress.c_str());
+
     if (xiloader::network::ResolveHostname(globals::g_ServerAddress.c_str(), &ulAddress))
     {
         globals::g_ServerAddress = inet_ntoa(*((struct in_addr*)&ulAddress));
+
+        xiloader::console::output(xiloader::color::info, "Resolved server address to '%s:%s'", globals::g_ServerAddress.c_str(), globals::g_LoginAuthPort.c_str());
 
         /* Attempt to create socket to server..*/
         xiloader::datasocket sock;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ namespace globals
     std::string        g_Password        = "";                          // The password being logged in with.
     char               g_SessionHash[16] = {};                          // Session hash sent from auth
     std::string        g_Email           = "";                          // Email, currently unused
-    std::string        g_VersionNumber   = "1.1.2";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'. Remember to also change in xiloader.rc.in
+    std::string        g_VersionNumber   = "1.1.3";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'. Remember to also change in xiloader.rc.in
     bool               g_FirstLogin      = false;                       // set to true when --user --pass are both set to allow for autologin
 
     char* g_CharacterList = NULL;  // Pointer to the character list data being sent from the server.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ namespace globals
     char               g_SessionHash[16] = {};                          // Session hash sent from auth
     std::string        g_Email           = "";                          // Email, currently unused
     std::string        g_VersionNumber   = "1.1.2";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'. Remember to also change in xiloader.rc.in
+    bool               g_FirstLogin      = false;                       // set to true when --user --pass are both set to allow for autologin
 
     char* g_CharacterList = NULL;  // Pointer to the character list data being sent from the server.
     bool  g_IsRunning     = false; // Flag to determine if the network threads should hault.
@@ -429,6 +430,11 @@ int __cdecl main(int argc, char* argv[])
     globals::g_Username = args.is_used("--user") ? args.get<std::string>("--user") : globals::g_Username;
     globals::g_Password = args.is_used("--pass") ? args.get<std::string>("--pass") : globals::g_Password;
     globals::g_Email    = args.is_used("--email") ? args.get<std::string>("--email") : globals::g_Email;
+
+    if (args.is_used("--user") && args.is_used("--pass"))
+    {
+        globals::g_FirstLogin = true;
+    }
 
     if (args.is_used("--lang"))
     {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -41,6 +41,7 @@ namespace globals
     extern std::string g_LoginAuthPort;
     extern char*       g_CharacterList;
     extern bool        g_IsRunning;
+    extern bool        g_FirstLogin;
 }
 
 // mbed tls state
@@ -335,8 +336,6 @@ namespace xiloader
      */
     bool network::VerifyAccount(datasocket* sock)
     {
-        static bool bFirstLogin = true;
-
         unsigned char recvBuffer[1024] = { 0 };
         unsigned char sendBuffer[1024] = { 0 };
         std::string new_password       = "";
@@ -350,7 +349,7 @@ namespace xiloader
         }*/
 
         /* Determine if we should auto-login.. */
-        bool bUseAutoLogin = !globals::g_Username.empty() && !globals::g_Password.empty() && bFirstLogin;
+        bool bUseAutoLogin = !globals::g_Username.empty() && !globals::g_Password.empty() && globals::g_FirstLogin;
         if (bUseAutoLogin)
             xiloader::console::output(xiloader::color::lightgreen, "Autologin activated!");
 
@@ -456,8 +455,8 @@ namespace xiloader
         else
         {
             /* User has auto-login enabled.. */
-            sendBuffer[0x39] = 0x10;
-            bFirstLogin = false;
+            sendBuffer[0x39]      = 0x10;
+            globals::g_FirstLogin = false;
         }
 
         sendBuffer[0] = 0xFF; // Magic for new xiloader bits

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -152,15 +152,18 @@ namespace xiloader
             return 0;
         }
 
-        if ((mbedtls_net_connect(&sslState::server_fd, globals::g_ServerAddress.c_str(), port, MBEDTLS_NET_PROTO_TCP)) != 0)
+        int ret = 0;
+
+        ret = mbedtls_net_connect(&sslState::server_fd, globals::g_ServerAddress.c_str(), port, MBEDTLS_NET_PROTO_TCP);
+        if (ret != 0)
         {
-            xiloader::console::output(xiloader::color::error, "mbedtls_net_connect failed.");
+            xiloader::console::output(xiloader::color::error, "mbedtls_net_connect failed, (%s)", mbedtls_low_level_strerr(ret));
             return 0;
         }
 
-        if (mbedtls_ssl_config_defaults(&sslState::conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT) != 0)
+        if ((ret = mbedtls_ssl_config_defaults(&sslState::conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
         {
-            xiloader::console::output(xiloader::color::error, "mbedtls_ssl_config_defaults failed.");
+            xiloader::console::output(xiloader::color::error, "mbedtls_ssl_config_defaults failed, (%s)", mbedtls_low_level_strerr(ret));
             return 0;
         }
 
@@ -169,11 +172,9 @@ namespace xiloader
         mbedtls_ssl_conf_ca_chain(&sslState::conf, sslState::ca_chain.get(), NULL);
         mbedtls_ssl_conf_rng(&sslState::conf, mbedtls_ctr_drbg_random, &sslState::ctr_drbg);
 
-        int ret = 0;
-
         if ((ret = mbedtls_ssl_setup(&sslState::ssl, &sslState::conf)) != 0)
         {
-            xiloader::console::output(xiloader::color::error, "mbedtls_ssl_setup returned %d", ret);
+            xiloader::console::output(xiloader::color::error, "mbedtls_ssl_setup failed, (%s)", mbedtls_low_level_strerr(ret));
             return 0;
         }
 

--- a/src/xiloader.rc.in
+++ b/src/xiloader.rc.in
@@ -5,7 +5,7 @@ BEGIN
     BEGIN
         BLOCK "081604b0"
         BEGIN
-            VALUE "FileVersion", "1.1.2"
+            VALUE "FileVersion", "1.1.3"
         END
     END
 END

--- a/xiloader.manifest
+++ b/xiloader.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<!-- https://stackoverflow.com/a/44009779, set PerMonitorV2 -->
+	<!-- https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process -->
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- fallback for Windows 7 and 8 -->
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness> <!-- adding v1 as fallback would result in v2 not being applied to dialogs on capable systems -->
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>


### PR DESCRIPTION
Fixes #15 
Closes #28 

Attempt to tell windows to not DPI scale xiloader (FFXI/ashita etc) do not play well with scaling. Seems to work(?), at least it may do nothing. The manifest is in fact inside the file if you check with ml.exe

Autologin will now only report/attempt "autologin" if you specified --user/--username and --pass/--password

Better logging: new resolving/resolved white text is always logged
![image](https://github.com/user-attachments/assets/3c4418be-74fa-454b-b216-7b0db48fd7e4)
