### PR TITLE
feat: optional login_token boot (token-based launcher login)

### DIFF
--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -40,6 +40,7 @@ namespace globals
     extern bool                   g_FirstLogin;
     extern std::string            g_TrustToken;
     extern bool                   g_TrustThisComputer;
+    extern std::string            g_LoginToken;
 } // namespace globals
 
 #include "defines.h"
@@ -156,6 +157,19 @@ bool handleLoginCommand(int8_t command, json& login_reply_json, uint32_t& accoun
             xiloader::console::output(xiloader::color::error, "==========================================================");
             xiloader::console::output(xiloader::color::error, "Trust token rejected! It has been cleared from this computer.");
             xiloader::console::output(xiloader::color::error, "Please log in again and enter your OTP code.");
+            xiloader::console::output(xiloader::color::error, "==========================================================");
+
+            return false;
+        }
+
+        // LOGIN_ERROR_LAUNCH_TOKEN_INVALID
+        case 0x0014:
+        {
+            // Single-use and short-lived; invalid means it was already used or expired.
+            globals::g_LoginToken.clear();
+            xiloader::console::output(xiloader::color::error, "==========================================================");
+            xiloader::console::output(xiloader::color::error, "Launch token invalid or expired (session expired).");
+            xiloader::console::output(xiloader::color::error, "Please log in again from the launcher.");
             xiloader::console::output(xiloader::color::error, "==========================================================");
 
             return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ namespace globals
     bool                   g_FirstLogin        = false;                       // set to true when --user --pass are both set to allow for autologin
     std::string            g_TrustToken        = "";                          // trust token loaded from disk or received from server
     bool                   g_TrustThisComputer = false;                       // user checkbox / CLI flag for "trust this computer"
+    std::string            g_LoginToken        = "";                          // single-use launch token from the launcher; sent in place of password + OTP
 
     char* g_CharacterList = NULL;  // Pointer to the character list data being sent from the server.
     bool  g_IsRunning     = false; // Flag to determine if the network threads should hault.
@@ -569,8 +570,13 @@ int __cdecl main(int argc, char* argv[])
                 globals::g_Username = maybeUsername.value_or(globals::g_Username);
                 globals::g_Password = maybePassword.value_or(globals::g_Password);
 
-                // Set autologin if it isn't set already
-                if (maybeUsername.has_value() && maybePassword.has_value())
+                // Optional single-use launch token; sent in place of password + OTP.
+                globals::g_LoginToken = jsonGet<std::string>(jsonData, "login_token").value_or(globals::g_LoginToken);
+
+                // A launch-token boot has a username + token but no password, so
+                // it also enables autologin.
+                if (maybeUsername.has_value() &&
+                    (maybePassword.has_value() || !globals::g_LoginToken.empty()))
                 {
                     globals::g_FirstLogin = true;
                 }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -51,6 +51,7 @@ namespace globals
     extern bool                   g_FirstLogin;
     extern std::string            g_TrustToken;
     extern bool                   g_TrustThisComputer;
+    extern std::string            g_LoginToken;
 }
 
 // mbed tls state
@@ -493,10 +494,17 @@ namespace xiloader
         login_json["version"]      = globals::g_VersionNumber;
         login_json["command"]      = command;
 
-        if (command == 0x10) // Only send trust fields for login
+        if (command == 0x10) // Only send trust/launch fields for login
         {
             login_json["trust_token"]        = globals::g_TrustToken;
             login_json["trust_this_computer"] = globals::g_TrustThisComputer;
+
+            // Optional single-use launch token; xi_connect consumes it in place
+            // of password + OTP (password may be empty).
+            if (!globals::g_LoginToken.empty())
+            {
+                login_json["login_token"] = globals::g_LoginToken;
+            }
         }
 
         std::string str          = login_json.dump();


### PR DESCRIPTION
## Summary

Client-side counterpart to a server change: parse an optional **`login_token`** from the `--json` config and send it in the `0x10` login JSON, so a launcher can boot the game with a single-use, short-TTL token minted by an external auth service instead of a stored password. This supports launchers built around OAuth/SSO sign-in (e.g. "Login with Discord") where there is an authenticated app session but no game password.

Companion server PR: **LandSandBoat/server#10421** (adds the `login_token` rail to `xi_connect`'s `LOGIN_ATTEMPT` + the `accounts_login_tokens` table). This client change is harmless without it (the server simply ignores an unknown JSON field).

## Changes

- New global `g_LoginToken`, populated from `jsonGet(jsonData, "login_token")` in the `--json` parse block.
- A username + `login_token` (no password) now enables autologin, alongside the existing username+password case.
- In the `0x10` login JSON, send `login_token` when present (next to the existing `trust_token` / `trust_this_computer` fields). Password may be empty on this path.
- Handle the new server result `LOGIN_ERROR_LAUNCH_TOKEN_INVALID = 0x14` with a "session expired, log in again from the launcher" message and clear the token.

## Backward compatibility

`login_token` is **optional**. When absent, the existing username/password and trust-token paths are completely unchanged. No protocol version bump.

## Notes for reviewers

- We run this on our fork (Phoenix); opening upstream so it can live in `main` rather than only downstream.
